### PR TITLE
Edit EuRoC launch file to launch rviz at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,15 @@ Download and install instructions can be found at: http://eigen.tuxfamily.org. *
 Download and install instructions can be found at: http://opencv.org. **Required at leat 2.4.3**. **Tested with 2.4.11 and 3.3.1**.
 
 ## 2. Build and Run
-First, `git clone` the repository and `catkin_make` it. Then, to run `rvio` with single camera/IMU inputs from the ROS topics `/camera/image_raw` and `/imu`, a config file in *config* folder and the corresponding launch file in *launch* folder (for example, `rvio_euroc.yaml` and `euroc.launch` are for [EuRoC](https://projects.asl.ethz.ch/datasets/doku.php?id=kmavvisualinertialdatasets) dataset) are needed, and to visualize the outputs of R-VIO please use `rviz` with the settings file `rvio_rviz.rviz` in *config* folder.
-  ```
-  Terminal 1: roscore
-  ```
-  ```
-  Terminal 2: rviz (AND OPEN rvio_rviz.rviz IN THE CONFIG FOLDER)
-  ```
-  ```
-  Terminal 3: roslaunch rvio euroc.launch
-  ```
-  ```
-  Terminal 4: rosbag play --pause V1_01_easy.bag /cam0/image_raw:=/camera/image_raw /imu0:=/imu
-  ```
+First, `git clone` the repository and `catkin_make` it. Then, to run `rvio` with single camera/IMU inputs from the ROS topics `/camera/image_raw` and `/imu`, a config file in *config* folder and the corresponding launch file in *launch* folder (for example, `rvio_euroc.yaml` and `euroc.launch` are for [EuRoC](https://projects.asl.ethz.ch/datasets/doku.php?id=kmavvisualinertialdatasets) dataset) are needed, and to visualize the outputs of R-VIO please use `rviz` with the settings file `rvio_rviz.rviz` in *config* folder. Using the launch file `euroc.launch` will run both R-VIO and rviz for you:
+
+```
+Terminal 1: roslaunch rvio euroc.launch
+```
+```
+Terminal 2: rosbag play --pause V1_01_easy.bag /cam0/image_raw:=/camera/image_raw /imu0:=/imu
+```
+
 You can also run R-VIO with your own sensor (data) by creating a config file `rvio_NAME_OF_YOUR_DATA.yaml` in *config* folder and the corresponding launch file `NAME_OF_YOUR_DATA.launch` in *launch* folder referring to the above EuRoC example.
 
 ## 3. License

--- a/launch/euroc.launch
+++ b/launch/euroc.launch
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <launch>
-
     <!-- Config file -->
     <arg name="config" default="$(find rvio)/config/rvio_euroc.yaml" />
 
@@ -8,4 +7,6 @@
     <node name="rvio" pkg="rvio" type="rvio_mono" args="$(arg config)" output="screen">
     </node>
 
+    <!-- Launch rviz -->
+    <node type="rviz" name="rviz" pkg="rviz" args="-d $(find rvio)/config/rvio_rviz.rviz" />
 </launch>


### PR DESCRIPTION
This is so that instead of opening up 4 terminals to use R-VIO, you only launch 2. 

1. For R-VIO
2. For playing the rosbag

By default when you do `roslaunch` it will check if an existing `roscore` already exists, if not it will create one for you.